### PR TITLE
Fix module loading for marble arena script

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@ y<!-- Import maps polyfill -->
 
 <script type="importmap">
   {
-		"imports": {
-			"three": "https://unpkg.com/three@0.174.0/build/three.module"
-		}
-	}
+                "imports": {
+                        "three": "https://unpkg.com/three@0.174.0/build/three.module.js"
+                }
+        }
 </script>
-<script src="marble_arena_prototype.js"></script>
+<script type="module" src="marble_arena_prototype.js"></script>
 <div id="sudden-death-label" style="
   position: fixed;
   top: 20px;


### PR DESCRIPTION
## Summary
- update the import map entry for Three.js to reference the module build with the .js extension
- load marble_arena_prototype.js as an ES module so its import statements execute in the browser

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1a4dd36288328a1505ac43a8f0e04