### PR TITLE
Fix CPU respawn scope

### DIFF
--- a/marble_arena_prototype.js
+++ b/marble_arena_prototype.js
@@ -2444,6 +2444,8 @@ dot.style.transform = `translate(-50%, -50%) translate(${tiltForce.x * maxOffset
         }
         for (let i = 0; i < cpuBodies.length; i++) {
           if (health.cpu[i] <= 0) {
+            const color = cpuMarbles[i].material.color.getHex();
+            const body = cpuBodies[i];
             createFallParticles(cpuMarbles[i].position, color);
             cpuLives[i]++;
             document.getElementById(`score-cpu-${i}`).textContent = cpuLives[i];
@@ -2453,7 +2455,7 @@ dot.style.transform = `translate(-50%, -50%) translate(${tiltForce.x * maxOffset
             if (cpuLives[i] < maxlives) {
               respawn(body, x, z);
             }
-            
+
           } else if (health.cpu[i] <= 10) {
             triggerSuddenDeath(cpuMarbles[i], cpuBodies[i], false, i);
           }


### PR DESCRIPTION
## Summary
- ensure CPU projectile death handling references the correct marble color and body variables within scope
- use the captured body when calling respawn to avoid undefined references

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1a9ce7e2c8328a29a04e4c37fd883