### PR TITLE
Fix tilt orientation and move scoreboard behind mobile controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,25 +51,14 @@
     </div>
   </div>
 
-<div id="scoreboard" style="
-  position: fixed;
-  top: 10px;
-  right: 10px;
-  background: rgba(0,0,0,0.6);
-  color: white;
-  padding: 10px;
-  font-family: sans-serif;
-  font-size: 14px;
-  border-radius: 6px;
-  z-index: 10;
-">
+<div id="scoreboard">
   <div><strong>Player Lives:</strong> <span id="score-lives">0</span></div>
   <div><strong>CPU 1 Lives:</strong> <span id="score-cpu-0">0</span></div>
   <div><strong>CPU 2 Lives:</strong> <span id="score-cpu-1">0</span></div>
   <div><strong>CPU 3 Lives:</strong> <span id="score-cpu-2">0</span></div>
   <hr>
   <div><strong>Kill Feed:</strong></div>
-  <div id="kill-feed" style="max-height: 100px; overflow-y: auto;"></div>
+  <div id="kill-feed"></div>
 </div>
 
 <div id="match-summary" style="

--- a/marble_arena_prototype.js
+++ b/marble_arena_prototype.js
@@ -220,9 +220,9 @@ setWireframeMode(false);
       const normX = Math.max(-1, Math.min(1, event.gamma / maxTilt)) * scale;
       const normZ = Math.max(-1, Math.min(1, event.beta / maxTilt)) * scale;
 
-      // Only flip controls when the device is upside-down; portrait and landscape use the same axes
+      // Rotate tilt vector to keep controls aligned across orientations (portrait & both landscapes)
       const orientation = ((getScreenOrientationAngle() % 360) + 360) % 360;
-      const angle = orientation === 180 ? Math.PI : 0;
+      const angle = (-orientation * Math.PI) / 180;
       const cos = Math.cos(angle);
       const sin = Math.sin(angle);
       tiltForce.x = normX * cos - normZ * sin;

--- a/style.css
+++ b/style.css
@@ -12,6 +12,25 @@ canvas { display: block; }
   border-radius: 6px;
   font-size: 14px;
 }
+
+#scoreboard {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  padding: 10px;
+  font-family: sans-serif;
+  font-size: 14px;
+  border-radius: 6px;
+  z-index: 5;
+  pointer-events: none;
+}
+
+#kill-feed {
+  max-height: 100px;
+  overflow-y: auto;
+}
 #hud.low-health {
   animation: lowflash 0.5s steps(1) infinite;
 }


### PR DESCRIPTION
## Summary
- style the scoreboard/kill feed on the right with lower z-index and no pointer events so mobile buttons remain usable when overlapping
- rotate device tilt input based on screen orientation to keep controls aligned in landscape and portrait modes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a6d34850832888ca5673f2a1ae04)