### PR TITLE
Fix unmatched brace causing syntax error

### DIFF
--- a/marble_arena_prototype.js
+++ b/marble_arena_prototype.js
@@ -2829,9 +2829,8 @@ dot.style.transform = `translate(-50%, -50%) translate(${tiltForce.x * maxOffset
       });
     }
 
-    function onWindowResize() {
-      camera.aspect = window.innerWidth / window.innerHeight;
-      camera.updateProjectionMatrix();
-      renderer.setSize(window.innerWidth, window.innerHeight);
-    }
-}
+  function onWindowResize() {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  }


### PR DESCRIPTION
## Summary
- remove an extraneous closing brace at the end of the prototype script
- keep the window resize handler defined at the top level without introducing syntax errors

## Testing
- node --check marble_arena_prototype.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946fa04658c8328932acd7e83f01767)