### PR TITLE
Ensure three.js imports use shared import map

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,11 @@
 
 <script type="importmap">
   {
-                "imports": {
-                        "three": "https://unpkg.com/three@0.174.0/build/three.module.js"
-                }
-        }
+    "imports": {
+      "three": "https://unpkg.com/three@0.174.0/build/three.module.js",
+      "three/examples/jsm/": "https://unpkg.com/three@0.174.0/examples/jsm/"
+    }
+  }
 </script>
 <script type="module" src="marble_arena_prototype.js"></script>
 <div id="sudden-death-label" style="

--- a/marble_arena_prototype.js
+++ b/marble_arena_prototype.js
@@ -1,12 +1,12 @@
 // marble_arena_prototype.js
 
-import * as THREE from 'https://unpkg.com/three@0.174.0/build/three.module.js';
+import * as THREE from 'three';
 import {
   OrbitControls
-} from 'https://unpkg.com/three@0.174.0/examples/jsm/controls/OrbitControls';
+} from 'three/examples/jsm/controls/OrbitControls.js';
 import * as CANNON from 'https://unpkg.com/cannon-es@0.20.0/dist/cannon-es.js';
-import * as BufferGeometryUtils from 'https://unpkg.com/three@0.174.0/examples/jsm/utils/BufferGeometryUtils.js';
-import { Water } from 'https://unpkg.com/three@0.174.0/examples/jsm/objects/Water.js';
+import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { Water } from 'three/examples/jsm/objects/Water.js';
 import CannonDebugger from 'https://cdn.skypack.dev/cannon-es-debugger';
 
 // load music


### PR DESCRIPTION
## Summary
- update import map to include three.js examples path
- switch three.js imports to bare specifiers so a single instance loads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946fe218e748328ba9f9bb18300eef1)