### PR TITLE
Revert import-map module usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,7 @@
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.174.0/build/three.module.js",
-      "three/examples/jsm/": "https://unpkg.com/three@0.174.0/examples/jsm/",
-      "cannon-es": "https://unpkg.com/cannon-es@0.20.0/dist/cannon-es.js",
-      "cannon-es-debugger": "https://unpkg.com/cannon-es-debugger@1.0.0/dist/cannon-es-debugger.es.js"
+      "three": "https://unpkg.com/three@0.174.0/build/three.module"
     }
   }
 </script>

--- a/marble_arena_prototype.js
+++ b/marble_arena_prototype.js
@@ -1,13 +1,13 @@
 // marble_arena_prototype.js
 
-import * as THREE from 'three';
+import * as THREE from 'https://unpkg.com/three@0.174.0/build/three.module.js';
 import {
   OrbitControls
-} from 'three/examples/jsm/controls/OrbitControls.js';
-import * as CANNON from 'cannon-es';
-import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
-import { Water } from 'three/examples/jsm/objects/Water.js';
-import CannonDebugger from 'cannon-es-debugger';
+} from 'https://unpkg.com/three@0.174.0/examples/jsm/controls/OrbitControls.js';
+import * as CANNON from 'https://unpkg.com/cannon-es@0.20.0/dist/cannon-es.js';
+import * as BufferGeometryUtils from 'https://unpkg.com/three@0.174.0/examples/jsm/utils/BufferGeometryUtils.js';
+import { Water } from 'https://unpkg.com/three@0.174.0/examples/jsm/objects/Water.js';
+import CannonDebugger from 'https://cdn.skypack.dev/cannon-es-debugger';
 
 // load music
 const listener = new THREE.AudioListener();


### PR DESCRIPTION
## Summary
- revert three.js and physics imports to use working CDN URLs
- simplify import map to match older configuration that initializes three.js correctly

## Testing
- not run (browser-based project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948614cb3f48328b99027a8bba30152)