### PR TITLE
Adjust debug controls and wireframe toggling

### DIFF
--- a/marble_arena_prototype.js
+++ b/marble_arena_prototype.js
@@ -54,6 +54,12 @@ let mobileControlsInitialized = false;
 const DEBUG_MODE = true;
 let wireframeToggleButton = null;
 let waterToggleButton = null;
+let preDebuggerObjects;
+
+function refreshCannonDebugObjects() {
+  if (!scene || !preDebuggerObjects) return;
+  cannonDebugObjects = scene.children.filter((child) => !preDebuggerObjects.has(child));
+}
 
 function applyWireframeToMaterial(material, enabled) {
   if (!material || typeof material !== 'object') return;
@@ -77,13 +83,14 @@ function applyWireframeToScene(enabled) {
 
 function setWireframeMode(enabled) {
   wireframeEnabled = enabled;
+  if (enabled && cannonDebugger?.update) {
+    cannonDebugger.update();
+    refreshCannonDebugObjects();
+  }
   applyWireframeToScene(enabled);
   cannonDebugObjects.forEach((obj) => {
     obj.visible = enabled;
   });
-  if (enabled && cannonDebugger?.update) {
-    cannonDebugger.update();
-  }
   if (wireframeToggleButton) {
     wireframeToggleButton.textContent = `Wireframe: ${enabled ? 'On' : 'Off'}`;
   }
@@ -109,11 +116,11 @@ const wallSegments = 16;
 
     init();
 
-const preDebuggerObjects = new Set(scene.children);
+preDebuggerObjects = new Set(scene.children);
 const cannonDebugger = CannonDebugger(scene, world, {
   color: 0xff00ff,
 });
-cannonDebugObjects = scene.children.filter((child) => !preDebuggerObjects.has(child));
+refreshCannonDebugObjects();
 setWireframeMode(false);
 
     // Joystick fallback for tilt control
@@ -2640,9 +2647,14 @@ dot.style.transform = `translate(-50%, -50%) translate(${tiltForce.x * maxOffset
     }  
       if (wireframeEnabled) {
         applyWireframeToScene(true);
-      }
-      if (wireframeEnabled && cannonDebugger?.update) {
-        cannonDebugger.update();
+        if (cannonDebugger?.update) {
+          cannonDebugger.update();
+          refreshCannonDebugObjects();
+        }
+      } else {
+        cannonDebugObjects.forEach((obj) => {
+          obj.visible = false;
+        });
       }
       renderer.render(scene, camera);
     }

--- a/style.css
+++ b/style.css
@@ -92,13 +92,14 @@ canvas { display: block; }
 
 #debug-controls {
   position: fixed;
-  bottom: 20px;
-  right: 20px;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
   display: none;
   flex-direction: row;
   gap: 10px;
   background: rgba(0, 0, 0, 0.5);
-  padding: 8px;
+  padding: 8px 10px;
   border-radius: 10px;
   z-index: 11;
 }


### PR DESCRIPTION
## Summary
- move debug toggle controls to the top center of the viewport for easier access
- refresh and hide cannon debug visuals appropriately when leaving wireframe mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949d0b977dc8328ac9444a1ba0681fc)