### PR TITLE
Add FPS display below player lives

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
 
 <div id="scoreboard">
   <div><strong>Player Lives:</strong> <span id="score-lives">0</span></div>
+  <div class="scoreboard-subtext" id="fps-row"><strong>FPS:</strong> <span id="fps-value">--</span></div>
   <div><strong>CPU 1 Lives:</strong> <span id="score-cpu-0">0</span></div>
   <div><strong>CPU 2 Lives:</strong> <span id="score-cpu-1">0</span></div>
   <div><strong>CPU 3 Lives:</strong> <span id="score-cpu-2">0</span></div>

--- a/marble_arena_prototype.js
+++ b/marble_arena_prototype.js
@@ -55,6 +55,10 @@ const DEBUG_MODE = true;
 let wireframeToggleButton = null;
 let waterToggleButton = null;
 let preDebuggerObjects;
+let fpsValueElement = null;
+let lastFrameTime = performance.now();
+let smoothedFps = 0;
+let fpsFrameCounter = 0;
 
 function refreshCannonDebugObjects() {
   if (!scene || !preDebuggerObjects) return;
@@ -465,11 +469,13 @@ function init_powerups() {
   scene.userData.powerups = [shieldPickup];
 }
 
-function init() {  
+function init() {
   // Scene setup
   scene = new THREE.Scene();
   scene.background = new THREE.Color(0xa0d8f0);
   scene.fog = new THREE.FogExp2(0xb0c4de, 0.02);
+
+  fpsValueElement = document.getElementById('fps-value');
 
   camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 1000);
   camera.add(listener);
@@ -2383,7 +2389,18 @@ function showMatchSummary() {
   });
 }
 
-function animate() {
+function animate(time) {
+  const now = typeof time === 'number' ? time : performance.now();
+  const delta = now - lastFrameTime;
+  if (delta > 0) {
+    const instantaneousFps = 1000 / delta;
+    smoothedFps = smoothedFps === 0 ? instantaneousFps : smoothedFps * 0.9 + instantaneousFps * 0.1;
+    if (fpsValueElement && fpsFrameCounter++ % 15 === 0) {
+      fpsValueElement.textContent = `${Math.round(smoothedFps)}`;
+    }
+  }
+  lastFrameTime = now;
+
   if (isMobileDevice()) {
     const indicator = document.getElementById('tilt-indicator');
     const dot = document.getElementById('tilt-dot');

--- a/style.css
+++ b/style.css
@@ -27,6 +27,12 @@ canvas { display: block; }
   pointer-events: none;
 }
 
+#scoreboard .scoreboard-subtext {
+  margin-top: 4px;
+  font-size: 12px;
+  opacity: 0.85;
+}
+
 #kill-feed {
   max-height: 100px;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- add an FPS row under the player lives counter on the scoreboard
- style the new scoreboard subtext entry for readability
- calculate and update a smoothed FPS value each frame during the game loop

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e8256e7c8328a5887070cac70d44)